### PR TITLE
WIP: make updates to work with webpack

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,73 +1,64 @@
-'use strict';
+"use strict";
 
-const packagePath = 'node_modules/serverless-offline-direct-lambda';
+const packagePath = "node_modules/serverless-offline-direct-lambda";
 const handlerPath = `proxy.js`;
 
-var AWS_SDK_USED = process.env.AWS_SDK_USED || 'rails';
+var AWS_SDK_USED = process.env.AWS_SDK_USED || "rails";
 function AWS_SDK_METHOD(functionBeingProxied, location) {
-
-    if(AWS_SDK_USED == 'node') {
-
-        // Additional support to call the function from the AWS SDK (NodeJS) directly...
-        var AWS_SDK_NODE_METHOD = {
-          http: {
-            method: 'POST',
-            // This is the path to the Lambda API..
-            path: `2015-03-31/functions/${functionBeingProxied.name}/invocations`,
-            integration: 'lambda',
-            request: {
-              template: {
-                // NB: AWS SDK for NodeJS specifies as 'binary/octet-stream' not 'application/json'
-                'binary/octet-stream': JSON.stringify(
-                  {
-                    location,   
-                    body: "$input.body",
-                    targetHandler :  functionBeingProxied.handler,
-                  }
-                )
-              }
-            },
-            response: {
-              headers: {
-                "Content-Type": "application/json"
-              }
-            }
+  if (AWS_SDK_USED == "node") {
+    // Additional support to call the function from the AWS SDK (NodeJS) directly...
+    var AWS_SDK_NODE_METHOD = {
+      http: {
+        method: "POST",
+        // This is the path to the Lambda API..
+        path: `2015-03-31/functions/${functionBeingProxied.name}/invocations`,
+        integration: "lambda",
+        request: {
+          template: {
+            // NB: AWS SDK for NodeJS specifies as 'binary/octet-stream' not 'application/json'
+            "binary/octet-stream": JSON.stringify({
+              location,
+              body: "$input.body",
+              targetHandler: functionBeingProxied.handler
+            })
           }
-        };
-        return AWS_SDK_NODE_METHOD;
-
-    } else {
-
-        // Additional support to call the function from the All other SDK's (Don't ask why AWS did it like this ......)
-        var AWS_SDK_RAILS_METHOD = {
-          http: {
-            method: 'POST',
-            // This is the path to the Lambda API..
-            path: `2015-03-31/functions/${functionBeingProxied.name}/invocations`,
-            integration: 'lambda',
-            request: {
-              template: {
-                // NB: AWS SDK for NodeJS specifies as 'binary/octet-stream' not 'application/json'
-                'application/json': JSON.stringify(
-                  {
-                    location,   
-                    body: "$input.json('$')",
-                    targetHandler :  functionBeingProxied.handler,
-                  }
-                )
-              }
-            },
-            response: {
-              headers: {
-                "Content-Type": "application/json"
-              }
-            }
+        },
+        response: {
+          headers: {
+            "Content-Type": "application/json"
           }
-        };
-        return AWS_SDK_RAILS_METHOD;
-    }
-
-};
+        }
+      }
+    };
+    return AWS_SDK_NODE_METHOD;
+  } else {
+    // Additional support to call the function from the All other SDK's (Don't ask why AWS did it like this ......)
+    var AWS_SDK_RAILS_METHOD = {
+      http: {
+        method: "POST",
+        // This is the path to the Lambda API..
+        path: `2015-03-31/functions/${functionBeingProxied.name}/invocations`,
+        integration: "lambda",
+        request: {
+          template: {
+            // NB: AWS SDK for NodeJS specifies as 'binary/octet-stream' not 'application/json'
+            "application/json": JSON.stringify({
+              location,
+              body: "$input.json('$')",
+              targetHandler: functionBeingProxied.handler
+            })
+          }
+        },
+        response: {
+          headers: {
+            "Content-Type": "application/json"
+          }
+        }
+      }
+    };
+    return AWS_SDK_RAILS_METHOD;
+  }
+}
 
 class ServerlessPlugin {
   constructor(serverless, options) {
@@ -75,18 +66,20 @@ class ServerlessPlugin {
     this.options = options;
 
     this.hooks = {
-      "before:offline:start:init": this.startHandler.bind(this),
+      "before:offline:start": this.startHandler.bind(this)
     };
   }
 
   startHandler() {
-    let location = '';
+    let location = "";
     try {
-      location = this.serverless.service.custom['serverless-offline'].location;
-      this.serverless.service.custom['serverless-offline'].location = '';
-    } catch (_) { }
+      location = this.serverless.service.custom["serverless-offline"].location;
+      this.serverless.service.custom["serverless-offline"].location = "";
+    } catch (_) {}
 
-    this.serverless.cli.log('Running Serverless Offline with direct lambda support');
+    this.serverless.cli.log(
+      "Running Serverless Offline with direct lambda support"
+    );
 
     addProxies(this.serverless.service.functions, location);
   }
@@ -94,7 +87,6 @@ class ServerlessPlugin {
 
 const addProxies = (functionsObject, location) => {
   Object.keys(functionsObject).forEach(fn => {
-
     // filter out functions with event config,
     // leaving just those intended for direct lambda-to-lambda invocation
     const functionObject = functionsObject[fn];
@@ -113,18 +105,16 @@ const functionProxy = (functionBeingProxied, location) => ({
     // This is the original `/post/FUNCTION-NAME` from the plugin...
     {
       http: {
-        method: 'POST',
+        method: "POST",
         path: `proxy/${functionBeingProxied.name}`,
-        integration: 'lambda',
+        integration: "lambda",
         request: {
           template: {
-            'application/json': JSON.stringify(
-              {
-                location,
-                body: "$input.json('$')",
-                targetHandler :  functionBeingProxied.handler,
-              }
-            )
+            "application/json": JSON.stringify({
+              location,
+              body: "$input.json('$')",
+              targetHandler: functionBeingProxied.handler
+            })
           }
         },
         response: {
@@ -132,13 +122,12 @@ const functionProxy = (functionBeingProxied, location) => ({
         }
       }
     },
- 
+
     // See methods above for further details
     AWS_SDK_METHOD(functionBeingProxied, location)
-
   ],
   package: {
-    include: [handlerPath],
+    include: [handlerPath]
   }
 });
 

--- a/proxy.js
+++ b/proxy.js
@@ -1,27 +1,33 @@
-const serializeError = require('serialize-error');
-const path = require('path');
+const serializeError = require("serialize-error");
+const path = require("path");
 
 function handler(event, context, callback) {
-
-  const [targetHandlerFile, targetHandlerFunction] = event.targetHandler.split(".");
-  const target = require(path.resolve(__dirname, '../..', targetHandlerFile));
+  const [targetHandlerFile, targetHandlerFunction] = event.targetHandler.split(
+    "."
+  );
+  /**
+   * When using webpack, this path needs to be relative to where the file is after being
+   * compiled.
+   */
+  const target = require(path.resolve(
+    __dirname,
+    "../../.webpack/services",
+    targetHandlerFile
+  ));
 
   target[targetHandlerFunction](event.body, context, (error, response) => {
-
     if (error) {
-        // Return Serverless error to AWS sdk
-        callback(null, {
-            StatusCode: 500,
-            FunctionError: 'Handled',
-            Payload: serializeError(error)
-        })
+      // Return Serverless error to AWS sdk
+      callback(null, {
+        StatusCode: 500,
+        FunctionError: "Handled",
+        Payload: serializeError(error)
+      });
     } else {
-        // Return lambda function response to AWS SDK & pass through args from serverless.
-        callback(null, response)
+      // Return lambda function response to AWS SDK & pass through args from serverless.
+      callback(null, response);
     }
   });
-
-
 }
 
 module.exports.handler = handler;


### PR DESCRIPTION
Attempting to add support for using this alongside serverless-webpack. So far I had to change the "hook" where this runs, which I think makes it run prior to webpack (without this change the function to invoke the proxy never got called).

There's still an issue where the proxy doesn't work because it can't find the module containing the function handler. I tried changing the path that's being `require`'d to be relative to the `.webpack` folder but it still throws an error saying it can't find the module. If I put a breakpoint in the code at that point and try to load the exact same path with plain `require` it works fine, but when the code is compiled it's using `__webpack_require__`... so I think it's doing something special in there.

TODO:
 - [ ] figure out missing module error 